### PR TITLE
fix(timezone): preserve millisecond precision in getEasternTimeISO

### DIFF
--- a/api/utils/timezone.js
+++ b/api/utils/timezone.js
@@ -8,6 +8,7 @@
  * @returns {string} ISO 8601 formatted timestamp in Eastern Time
  */
 export function getEasternTimeISO() {
+  const now = new Date();
   const formatter = new Intl.DateTimeFormat('en-US', {
     timeZone: 'America/New_York',
     year: 'numeric',
@@ -19,12 +20,15 @@ export function getEasternTimeISO() {
     hour12: false
   });
 
-  const parts = formatter.formatToParts(new Date());
+  const parts = formatter.formatToParts(now);
   const values = {};
   parts.forEach(part => values[part.type] = part.value);
 
+  // Preserve milliseconds from the original Date object
+  const milliseconds = now.getMilliseconds().toString().padStart(3, '0');
+
   return new Date(
-    `${values.year}-${values.month}-${values.day}T${values.hour}:${values.minute}:${values.second}`
+    `${values.year}-${values.month}-${values.day}T${values.hour}:${values.minute}:${values.second}.${milliseconds}`
   ).toISOString();
 }
 


### PR DESCRIPTION
## Summary
- Fixes test failure in `getEasternTimeISO()` where timestamps within the same second were identical
- Preserves millisecond precision by capturing and including milliseconds from the original Date object
- All 66 tests now passing

## Changes
The previous implementation lost millisecond precision because `Intl.DateTimeFormat` doesn't support milliseconds. This caused the test expecting different timestamps on subsequent calls to fail when executed rapidly.

**Fix:** Capture the original `Date` object's milliseconds and include them in the ISO string construction.

## Test Results
```
Test Suites: 4 passed, 4 total
Tests:       66 passed, 66 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)