### PR TITLE
test: add unit and integration tests for showtime filtering and timezone utilities

### DIFF
--- a/tests/integration/recording-status.test.js
+++ b/tests/integration/recording-status.test.js
@@ -1,0 +1,492 @@
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { createMocks } from 'node-mocks-http';
+import crypto from 'crypto';
+
+// Helper to generate Twilio signature
+function getExpectedTwilioSignature(authToken, url, params) {
+  const data = Object.keys(params)
+    .sort()
+    .reduce((acc, key) => acc + key + params[key], url);
+
+  return crypto
+    .createHmac('sha1', authToken)
+    .update(Buffer.from(data, 'utf-8'))
+    .digest('base64');
+}
+
+// Mock Redis client
+class MockRedis {
+  constructor() {
+    this.data = new Map();
+  }
+
+  async get(key) {
+    const value = this.data.get(key);
+    return value || null;
+  }
+
+  async set(key, value) {
+    this.data.set(key, value);
+    return 'OK';
+  }
+
+  clear() {
+    this.data.clear();
+  }
+}
+
+describe('Recording Status Callback (Integration Test)', () => {
+  let originalEnv;
+  let mockRedis;
+
+  beforeEach(() => {
+    // Save original environment
+    originalEnv = { ...process.env };
+
+    // Set test environment
+    process.env.BASE_URL = 'https://miami-theater-voice-agent.vercel.app';
+    process.env.TWILIO_AUTH_TOKEN = 'test-auth-token-12345';
+    process.env.TWILIO_ACCOUNT_SID = 'ACxxxxx';
+    process.env.KV_REST_API_URL = 'https://test-redis.upstash.io';
+    process.env.KV_REST_API_TOKEN = 'test-token';
+
+    // Create mock Redis instance
+    mockRedis = new MockRedis();
+  });
+
+  afterEach(() => {
+    // Restore environment
+    process.env = originalEnv;
+    jest.resetModules();
+    jest.clearAllMocks();
+    if (mockRedis) {
+      mockRedis.clear();
+    }
+  });
+
+  test('updates voicemail with recording status information', async () => {
+    // Mock Redis
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    // Pre-populate Redis with a voicemail record
+    const recordingSid = 'RE1234567890abcdef1234567890abcdef';
+    const existingVoicemail = {
+      id: recordingSid,
+      recordingUrl: 'https://api.twilio.com/recordings/RE1234567890abcdef1234567890abcdef',
+      duration: 45,
+      callSid: 'CAxxxxx',
+      from: '+12345678901',
+      to: '+19876543210',
+      status: 'completed',
+      createdAt: new Date('2024-01-15T10:30:00Z').toISOString(),
+      listened: false
+    };
+
+    await mockRedis.set(`voicemail:${recordingSid}`, JSON.stringify(existingVoicemail));
+
+    // Import handler after mocking
+    const statusHandler = (await import('../../api/twilio/recording-status.js?t=' + Date.now())).default;
+
+    // Prepare recording status callback data
+    const callbackUrl = 'https://miami-theater-voice-agent.vercel.app/api/twilio/recording-status';
+    const callbackParams = {
+      RecordingSid: recordingSid,
+      RecordingUrl: 'https://api.twilio.com/recordings/RE1234567890abcdef1234567890abcdef',
+      RecordingStatus: 'completed',
+      RecordingDuration: '47',
+      RecordingChannels: '1',
+      RecordingSource: 'RecordVerb'
+    };
+
+    // Generate valid Twilio signature
+    const signature = getExpectedTwilioSignature(
+      process.env.TWILIO_AUTH_TOKEN,
+      callbackUrl,
+      callbackParams
+    );
+
+    // Create request
+    const { req, res } = createMocks({
+      method: 'POST',
+      url: '/api/twilio/recording-status',
+      headers: {
+        'x-twilio-signature': signature,
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app',
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: callbackParams
+    });
+
+    await statusHandler(req, res);
+
+    // Verify response
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = JSON.parse(res._getData());
+    expect(responseData.success).toBe(true);
+
+    // Verify Redis was updated with recording status
+    const updatedVoicemail = await mockRedis.get(`voicemail:${recordingSid}`);
+    expect(updatedVoicemail).toBeTruthy();
+
+    const voicemailData = JSON.parse(updatedVoicemail);
+    expect(voicemailData.recordingStatus).toBe('completed');
+    expect(voicemailData.recordingChannels).toBe('1');
+    expect(voicemailData.recordingSource).toBe('RecordVerb');
+    expect(voicemailData.statusUpdatedAt).toBeTruthy();
+    expect(voicemailData.duration).toBe(47); // Updated duration
+  });
+
+  test('updates duration when status is completed', async () => {
+    // Mock Redis
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    const recordingSid = 'RE1234567890abcdef1234567890abcdef';
+    const existingVoicemail = {
+      id: recordingSid,
+      recordingUrl: 'https://api.twilio.com/recordings/RE1234567890abcdef1234567890abcdef',
+      duration: 0, // Initial duration unknown
+      from: '+12345678901',
+      createdAt: new Date().toISOString(),
+      listened: false
+    };
+
+    await mockRedis.set(`voicemail:${recordingSid}`, JSON.stringify(existingVoicemail));
+
+    const statusHandler = (await import('../../api/twilio/recording-status.js?t=' + Date.now())).default;
+
+    const callbackUrl = 'https://miami-theater-voice-agent.vercel.app/api/twilio/recording-status';
+    const callbackParams = {
+      RecordingSid: recordingSid,
+      RecordingUrl: 'https://api.twilio.com/recordings/RE1234567890abcdef1234567890abcdef',
+      RecordingStatus: 'completed',
+      RecordingDuration: '120'
+    };
+
+    const signature = getExpectedTwilioSignature(
+      process.env.TWILIO_AUTH_TOKEN,
+      callbackUrl,
+      callbackParams
+    );
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      url: '/api/twilio/recording-status',
+      headers: {
+        'x-twilio-signature': signature,
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app',
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: callbackParams
+    });
+
+    await statusHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const updatedVoicemail = await mockRedis.get(`voicemail:${recordingSid}`);
+    const voicemailData = JSON.parse(updatedVoicemail);
+
+    // Duration should be updated to 120 seconds
+    expect(voicemailData.duration).toBe(120);
+    expect(voicemailData.recordingStatus).toBe('completed');
+  });
+
+  test('stores error code when recording fails', async () => {
+    // Mock Redis
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    const recordingSid = 'RE1234567890abcdef1234567890abcdef';
+    const existingVoicemail = {
+      id: recordingSid,
+      recordingUrl: 'https://api.twilio.com/recordings/RE1234567890abcdef1234567890abcdef',
+      duration: 0,
+      from: '+12345678901',
+      createdAt: new Date().toISOString(),
+      listened: false
+    };
+
+    await mockRedis.set(`voicemail:${recordingSid}`, JSON.stringify(existingVoicemail));
+
+    const statusHandler = (await import('../../api/twilio/recording-status.js?t=' + Date.now())).default;
+
+    const callbackUrl = 'https://miami-theater-voice-agent.vercel.app/api/twilio/recording-status';
+    const callbackParams = {
+      RecordingSid: recordingSid,
+      RecordingUrl: 'https://api.twilio.com/recordings/RE1234567890abcdef1234567890abcdef',
+      RecordingStatus: 'failed',
+      ErrorCode: '13227' // Example Twilio error code
+    };
+
+    const signature = getExpectedTwilioSignature(
+      process.env.TWILIO_AUTH_TOKEN,
+      callbackUrl,
+      callbackParams
+    );
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      url: '/api/twilio/recording-status',
+      headers: {
+        'x-twilio-signature': signature,
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app',
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: callbackParams
+    });
+
+    await statusHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const updatedVoicemail = await mockRedis.get(`voicemail:${recordingSid}`);
+    const voicemailData = JSON.parse(updatedVoicemail);
+
+    expect(voicemailData.recordingStatus).toBe('failed');
+    expect(voicemailData.errorCode).toBe('13227');
+  });
+
+  test('does not update duration when status is not completed', async () => {
+    // Mock Redis
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    const recordingSid = 'RE1234567890abcdef1234567890abcdef';
+    const existingVoicemail = {
+      id: recordingSid,
+      recordingUrl: 'https://api.twilio.com/recordings/RE1234567890abcdef1234567890abcdef',
+      duration: 45, // Original duration
+      from: '+12345678901',
+      createdAt: new Date().toISOString(),
+      listened: false
+    };
+
+    await mockRedis.set(`voicemail:${recordingSid}`, JSON.stringify(existingVoicemail));
+
+    const statusHandler = (await import('../../api/twilio/recording-status.js?t=' + Date.now())).default;
+
+    const callbackUrl = 'https://miami-theater-voice-agent.vercel.app/api/twilio/recording-status';
+    const callbackParams = {
+      RecordingSid: recordingSid,
+      RecordingUrl: 'https://api.twilio.com/recordings/RE1234567890abcdef1234567890abcdef',
+      RecordingStatus: 'processing',
+      RecordingDuration: '999' // Should be ignored
+    };
+
+    const signature = getExpectedTwilioSignature(
+      process.env.TWILIO_AUTH_TOKEN,
+      callbackUrl,
+      callbackParams
+    );
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      url: '/api/twilio/recording-status',
+      headers: {
+        'x-twilio-signature': signature,
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app',
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: callbackParams
+    });
+
+    await statusHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const updatedVoicemail = await mockRedis.get(`voicemail:${recordingSid}`);
+    const voicemailData = JSON.parse(updatedVoicemail);
+
+    // Duration should remain unchanged
+    expect(voicemailData.duration).toBe(45);
+    expect(voicemailData.recordingStatus).toBe('processing');
+  });
+
+  test('handles missing voicemail record gracefully', async () => {
+    // Mock Redis
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    // Note: We do NOT pre-populate Redis, so the voicemail doesn't exist
+
+    const statusHandler = (await import('../../api/twilio/recording-status.js?t=' + Date.now())).default;
+
+    const callbackUrl = 'https://miami-theater-voice-agent.vercel.app/api/twilio/recording-status';
+    const callbackParams = {
+      RecordingSid: 'RE_DOES_NOT_EXIST',
+      RecordingUrl: 'https://api.twilio.com/recordings/RE_DOES_NOT_EXIST',
+      RecordingStatus: 'completed',
+      RecordingDuration: '60'
+    };
+
+    const signature = getExpectedTwilioSignature(
+      process.env.TWILIO_AUTH_TOKEN,
+      callbackUrl,
+      callbackParams
+    );
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      url: '/api/twilio/recording-status',
+      headers: {
+        'x-twilio-signature': signature,
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app',
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: callbackParams
+    });
+
+    await statusHandler(req, res);
+
+    // Should still return 200 (graceful handling)
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = JSON.parse(res._getData());
+    expect(responseData.success).toBe(true);
+  });
+
+  test('rejects invalid Twilio signature', async () => {
+    // Mock Redis
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    const statusHandler = (await import('../../api/twilio/recording-status.js?t=' + Date.now())).default;
+
+    const callbackParams = {
+      RecordingSid: 'RE1234567890abcdef1234567890abcdef',
+      RecordingUrl: 'https://api.twilio.com/recordings/RE1234567890abcdef1234567890abcdef',
+      RecordingStatus: 'completed',
+      RecordingDuration: '60'
+    };
+
+    // Create request with INVALID signature
+    const { req, res } = createMocks({
+      method: 'POST',
+      url: '/api/twilio/recording-status',
+      headers: {
+        'x-twilio-signature': 'invalid-signature-xyz',
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app',
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: callbackParams
+    });
+
+    await statusHandler(req, res);
+
+    // Should return 403 Forbidden
+    expect(res._getStatusCode()).toBe(403);
+    const responseData = JSON.parse(res._getData());
+    expect(responseData.error).toContain('Invalid signature');
+  });
+
+  test('rejects non-POST requests', async () => {
+    const statusHandler = (await import('../../api/twilio/recording-status.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'GET'
+    });
+
+    await statusHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    const responseData = JSON.parse(res._getData());
+    expect(responseData.error).toBe('Method not allowed');
+  });
+
+  test('returns 500 when TWILIO_AUTH_TOKEN is not configured', async () => {
+    // Remove auth token
+    delete process.env.TWILIO_AUTH_TOKEN;
+
+    const statusHandler = (await import('../../api/twilio/recording-status.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: {
+        'x-twilio-signature': 'some-signature'
+      },
+      body: {}
+    });
+
+    await statusHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    const responseData = JSON.parse(res._getData());
+    expect(responseData.error).toBe('Server configuration error');
+  });
+
+  test('handles recording with all status fields', async () => {
+    // Mock Redis
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    const recordingSid = 'RE1234567890abcdef1234567890abcdef';
+    const existingVoicemail = {
+      id: recordingSid,
+      recordingUrl: 'https://api.twilio.com/recordings/RE1234567890abcdef1234567890abcdef',
+      duration: 45,
+      from: '+12345678901',
+      createdAt: new Date().toISOString(),
+      listened: false
+    };
+
+    await mockRedis.set(`voicemail:${recordingSid}`, JSON.stringify(existingVoicemail));
+
+    const statusHandler = (await import('../../api/twilio/recording-status.js?t=' + Date.now())).default;
+
+    const callbackUrl = 'https://miami-theater-voice-agent.vercel.app/api/twilio/recording-status';
+    const callbackParams = {
+      RecordingSid: recordingSid,
+      RecordingUrl: 'https://api.twilio.com/recordings/RE1234567890abcdef1234567890abcdef',
+      RecordingStatus: 'completed',
+      RecordingDuration: '55',
+      RecordingChannels: '2',
+      RecordingSource: 'StartCallRecordingAPI'
+    };
+
+    const signature = getExpectedTwilioSignature(
+      process.env.TWILIO_AUTH_TOKEN,
+      callbackUrl,
+      callbackParams
+    );
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      url: '/api/twilio/recording-status',
+      headers: {
+        'x-twilio-signature': signature,
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app',
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: callbackParams
+    });
+
+    await statusHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const updatedVoicemail = await mockRedis.get(`voicemail:${recordingSid}`);
+    const voicemailData = JSON.parse(updatedVoicemail);
+
+    expect(voicemailData.recordingStatus).toBe('completed');
+    expect(voicemailData.recordingChannels).toBe('2');
+    expect(voicemailData.recordingSource).toBe('StartCallRecordingAPI');
+    expect(voicemailData.duration).toBe(55);
+    expect(voicemailData.statusUpdatedAt).toBeTruthy();
+    expect(new Date(voicemailData.statusUpdatedAt).getTime()).toBeGreaterThan(0);
+  });
+});

--- a/tests/integration/voicemail-callback.test.js
+++ b/tests/integration/voicemail-callback.test.js
@@ -1,0 +1,354 @@
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { createMocks } from 'node-mocks-http';
+import crypto from 'crypto';
+
+// Helper to generate Twilio signature
+function getExpectedTwilioSignature(authToken, url, params) {
+  const data = Object.keys(params)
+    .sort()
+    .reduce((acc, key) => acc + key + params[key], url);
+
+  return crypto
+    .createHmac('sha1', authToken)
+    .update(Buffer.from(data, 'utf-8'))
+    .digest('base64');
+}
+
+// Helper to parse TwiML and extract callback URLs
+function parseTwiMLCallbackUrl(twiml, verb = 'Record') {
+  const recordMatch = new RegExp(`<${verb}[^>]*action="([^"]*)"`, 'i').exec(twiml);
+  return recordMatch ? recordMatch[1] : null;
+}
+
+// Mock Redis client
+class MockRedis {
+  constructor() {
+    this.data = new Map();
+    this.sortedSets = new Map();
+  }
+
+  async get(key) {
+    const value = this.data.get(key);
+    return value || null;
+  }
+
+  async set(key, value) {
+    this.data.set(key, value);
+    return 'OK';
+  }
+
+  async setex(key, ttl, value) {
+    this.data.set(key, value);
+    return 'OK';
+  }
+
+  async zadd(key, options) {
+    if (!this.sortedSets.has(key)) {
+      this.sortedSets.set(key, []);
+    }
+    this.sortedSets.get(key).push({
+      score: options.score,
+      member: options.member
+    });
+    return 1;
+  }
+
+  async zrange(key, start, stop) {
+    const set = this.sortedSets.get(key) || [];
+    const sorted = set.sort((a, b) => a.score - b.score);
+
+    // Handle Redis-style negative indices
+    // -1 means "last element" in Redis, which translates to "no end limit" in slice
+    if (stop === -1) {
+      return sorted.slice(start).map(item => item.member);
+    }
+
+    return sorted.slice(start, stop + 1).map(item => item.member);
+  }
+
+  clear() {
+    this.data.clear();
+    this.sortedSets.clear();
+  }
+}
+
+describe('Voicemail Callback Flow (E2E Integration Test)', () => {
+  let originalEnv;
+  let mockRedis;
+  let emailSendSpy;
+
+  beforeEach(() => {
+    // Save original environment
+    originalEnv = { ...process.env };
+
+    // Set test environment
+    process.env.BASE_URL = 'https://miami-theater-voice-agent.vercel.app';
+    process.env.TWILIO_AUTH_TOKEN = 'test-auth-token-12345';
+    process.env.TWILIO_ACCOUNT_SID = 'ACxxxxx';
+    process.env.RESEND_API_KEY = 'test-resend-key';
+    process.env.STAFF_EMAIL = 'staff@o-cinema.org';
+    process.env.FROM_EMAIL = 'noreply@o-cinema.org';
+    process.env.KV_REST_API_URL = 'https://test-redis.upstash.io';
+    process.env.KV_REST_API_TOKEN = 'test-token';
+
+    // Create mock Redis instance
+    mockRedis = new MockRedis();
+
+    // Mock the email sending function
+    emailSendSpy = jest.fn().mockResolvedValue({ id: 'email-123' });
+  });
+
+  afterEach(() => {
+    // Restore environment
+    process.env = originalEnv;
+    jest.resetModules();
+    jest.clearAllMocks();
+    if (mockRedis) {
+      mockRedis.clear();
+    }
+  });
+
+  test('voicemail endpoint returns TwiML with callback URL', async () => {
+    // Import handler after setting up environment
+    const handler = (await import('../../api/twilio/voicemail.js')).default;
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: {
+        From: '+12345678901',
+        To: '+19876543210',
+        CallSid: 'CAxxxxx'
+      }
+    });
+
+    await handler(req, res);
+
+    // Verify response
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getHeaders()['content-type']).toBe('text/xml');
+
+    // Parse TwiML response
+    const twiml = res._getData();
+    expect(twiml).toContain('<Record');
+    expect(twiml).toContain('action=');
+
+    // Extract callback URL
+    const callbackUrl = parseTwiMLCallbackUrl(twiml, 'Record');
+    expect(callbackUrl).toBeTruthy();
+    expect(callbackUrl).toContain('/api/twilio/voicemail-callback');
+  });
+
+  test('callback is invoked and processes recording data correctly', async () => {
+    // Mock @upstash/redis module
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    // Mock email sending
+    jest.unstable_mockModule('../../api/utils/voicemail-email.js', () => ({
+      sendVoicemailEmail: emailSendSpy
+    }));
+
+    // Re-import handler after mocking
+    const callbackHandler = (await import('../../api/twilio/voicemail-callback.js?t=' + Date.now())).default;
+
+    // Prepare callback request data (what Twilio sends)
+    const callbackUrl = 'https://miami-theater-voice-agent.vercel.app/api/twilio/voicemail-callback';
+    const callbackParams = {
+      RecordingSid: 'RE1234567890abcdef1234567890abcdef',
+      RecordingUrl: 'https://api.twilio.com/2010-04-01/Accounts/ACxxxxx/Recordings/RE1234567890abcdef1234567890abcdef',
+      RecordingDuration: '45',
+      CallSid: 'CAxxxxx',
+      From: '+12345678901',
+      To: '+19876543210',
+      RecordingStatus: 'completed'
+    };
+
+    // Generate valid Twilio signature
+    const signature = getExpectedTwilioSignature(
+      process.env.TWILIO_AUTH_TOKEN,
+      callbackUrl,
+      callbackParams
+    );
+
+    // Create callback request
+    const { req, res } = createMocks({
+      method: 'POST',
+      url: '/api/twilio/voicemail-callback',
+      headers: {
+        'x-twilio-signature': signature,
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app',
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: callbackParams
+    });
+
+    // Call the callback endpoint
+    await callbackHandler(req, res);
+
+    // Verify response
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getHeaders()['content-type']).toBe('text/xml');
+
+    const responseTwiml = res._getData();
+    expect(responseTwiml).toContain('<Response>');
+    expect(responseTwiml).toContain('<Say');
+    expect(responseTwiml).toContain('Thank you');
+    expect(responseTwiml).toContain('<Hangup');
+
+    // Verify Redis storage
+    const storedVoicemail = await mockRedis.get(`voicemail:${callbackParams.RecordingSid}`);
+    expect(storedVoicemail).toBeTruthy();
+
+    const voicemailData = JSON.parse(storedVoicemail);
+    expect(voicemailData.id).toBe(callbackParams.RecordingSid);
+    expect(voicemailData.recordingUrl).toBe(callbackParams.RecordingUrl);
+    expect(voicemailData.duration).toBe(45);
+    expect(voicemailData.from).toBe(callbackParams.From);
+    expect(voicemailData.status).toBe('completed');
+    expect(voicemailData.listened).toBe(false);
+
+    // Verify sorted set index
+    const indexMembers = await mockRedis.zrange('voicemails:index', 0, -1);
+    expect(indexMembers).toContain(callbackParams.RecordingSid);
+
+    // Verify email notification was sent
+    expect(emailSendSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: callbackParams.RecordingSid,
+        recordingUrl: callbackParams.RecordingUrl,
+        from: callbackParams.From
+      }),
+      'new'
+    );
+  });
+
+  test('callback endpoint rejects invalid Twilio signature', async () => {
+    // Mock Redis
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    const callbackHandler = (await import('../../api/twilio/voicemail-callback.js?t=' + Date.now())).default;
+
+    const callbackParams = {
+      RecordingSid: 'RE1234567890abcdef1234567890abcdef',
+      RecordingUrl: 'https://api.twilio.com/recordings/RE123',
+      RecordingDuration: '45',
+      CallSid: 'CAxxxxx',
+      From: '+12345678901',
+      To: '+19876543210',
+      RecordingStatus: 'completed'
+    };
+
+    // Create request with INVALID signature
+    const { req, res } = createMocks({
+      method: 'POST',
+      url: '/api/twilio/voicemail-callback',
+      headers: {
+        'x-twilio-signature': 'invalid-signature-xyz',
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app',
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: callbackParams
+    });
+
+    await callbackHandler(req, res);
+
+    // Should return 403 Forbidden
+    expect(res._getStatusCode()).toBe(403);
+    const responseData = JSON.parse(res._getData());
+    expect(responseData.error).toContain('Invalid signature');
+
+    // Verify NO data was stored in Redis
+    const storedVoicemail = await mockRedis.get(`voicemail:${callbackParams.RecordingSid}`);
+    expect(storedVoicemail).toBeNull();
+  });
+
+  test('end-to-end flow: voicemail TwiML → callback invocation', async () => {
+    // Mock dependencies
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+    jest.unstable_mockModule('../../api/utils/voicemail-email.js', () => ({
+      sendVoicemailEmail: emailSendSpy
+    }));
+
+    // Step 1: Get TwiML from voicemail endpoint
+    const voicemailHandler = (await import('../../api/twilio/voicemail.js?t=' + Date.now())).default;
+
+    const { req: voicemailReq, res: voicemailRes } = createMocks({
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: {
+        From: '+12345678901',
+        To: '+19876543210',
+        CallSid: 'CAxxxxx'
+      }
+    });
+
+    await voicemailHandler(voicemailReq, voicemailRes);
+
+    // Extract callback URL from TwiML
+    const twiml = voicemailRes._getData();
+    const callbackUrl = parseTwiMLCallbackUrl(twiml, 'Record');
+
+    expect(callbackUrl).toBeTruthy();
+    expect(callbackUrl).toContain('/api/twilio/voicemail-callback');
+
+    // Step 2: Simulate Twilio calling the callback
+    const callbackHandler = (await import('../../api/twilio/voicemail-callback.js?t=' + Date.now())).default;
+
+    const callbackParams = {
+      RecordingSid: 'RE999888777666555444333222111',
+      RecordingUrl: 'https://api.twilio.com/recordings/RE999888777666555444333222111',
+      RecordingDuration: '120',
+      CallSid: 'CAxxxxx',
+      From: '+12345678901',
+      To: '+19876543210',
+      RecordingStatus: 'completed'
+    };
+
+    const fullCallbackUrl = `https://miami-theater-voice-agent.vercel.app${new URL(callbackUrl).pathname}`;
+    const signature = getExpectedTwilioSignature(
+      process.env.TWILIO_AUTH_TOKEN,
+      fullCallbackUrl,
+      callbackParams
+    );
+
+    const { req: callbackReq, res: callbackRes } = createMocks({
+      method: 'POST',
+      url: new URL(callbackUrl).pathname,
+      headers: {
+        'x-twilio-signature': signature,
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app',
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: callbackParams
+    });
+
+    await callbackHandler(callbackReq, callbackRes);
+
+    // Step 3: Verify the complete flow worked
+    expect(callbackRes._getStatusCode()).toBe(200);
+
+    // Verify data persisted
+    const storedVoicemail = await mockRedis.get(`voicemail:${callbackParams.RecordingSid}`);
+    expect(storedVoicemail).toBeTruthy();
+
+    const voicemailData = JSON.parse(storedVoicemail);
+    expect(voicemailData.duration).toBe(120);
+    expect(voicemailData.from).toBe('+12345678901');
+
+    // Verify email was sent
+    expect(emailSendSpy).toHaveBeenCalled();
+  });
+});

--- a/tests/integration/voicemail-list.test.js
+++ b/tests/integration/voicemail-list.test.js
@@ -1,0 +1,566 @@
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { createMocks } from 'node-mocks-http';
+
+// Mock Redis client with sorted set support
+class MockRedis {
+  constructor() {
+    this.data = new Map();
+    this.sortedSets = new Map();
+  }
+
+  async get(key) {
+    const value = this.data.get(key);
+    return value || null;
+  }
+
+  async set(key, value) {
+    this.data.set(key, value);
+    return 'OK';
+  }
+
+  async zrange(key, start, stop, options = {}) {
+    const set = this.sortedSets.get(key) || [];
+    let sorted = [...set].sort((a, b) => a.score - b.score);
+
+    // Reverse if requested (newest first)
+    if (options.rev) {
+      sorted = sorted.reverse();
+    }
+
+    // Handle Redis-style negative indices
+    if (stop === -1) {
+      return sorted.slice(start).map(item => item.member);
+    }
+
+    return sorted.slice(start, stop + 1).map(item => item.member);
+  }
+
+  async zadd(key, options) {
+    if (!this.sortedSets.has(key)) {
+      this.sortedSets.set(key, []);
+    }
+    this.sortedSets.get(key).push({
+      score: options.score,
+      member: options.member
+    });
+    return 1;
+  }
+
+  async zcard(key) {
+    const set = this.sortedSets.get(key) || [];
+    return set.length;
+  }
+
+  clear() {
+    this.data.clear();
+    this.sortedSets.clear();
+  }
+}
+
+describe('Voicemail List Endpoint (Integration Test)', () => {
+  let originalEnv;
+  let mockRedis;
+
+  beforeEach(() => {
+    // Save original environment
+    originalEnv = { ...process.env };
+
+    // Set test environment
+    process.env.STAFF_DASHBOARD_SECRET = 'test-secret-token-12345';
+    process.env.KV_REST_API_URL = 'https://test-redis.upstash.io';
+    process.env.KV_REST_API_TOKEN = 'test-token';
+
+    // Create mock Redis instance
+    mockRedis = new MockRedis();
+  });
+
+  afterEach(() => {
+    // Restore environment
+    process.env = originalEnv;
+    jest.resetModules();
+    jest.clearAllMocks();
+    if (mockRedis) {
+      mockRedis.clear();
+    }
+  });
+
+  test('authenticates with valid Bearer token and returns JSON', async () => {
+    // Mock Redis
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    // Add sample voicemails to Redis
+    const voicemail1 = {
+      id: 'RE111',
+      recordingUrl: 'https://api.twilio.com/recordings/RE111',
+      duration: 45,
+      from: '+12345678901',
+      to: '+19876543210',
+      transcription: 'Hello, this is a test message.',
+      createdAt: new Date('2024-01-15T10:00:00Z').toISOString(),
+      listened: false
+    };
+
+    const voicemail2 = {
+      id: 'RE222',
+      recordingUrl: 'https://api.twilio.com/recordings/RE222',
+      duration: 30,
+      from: '+13334445555',
+      to: '+19876543210',
+      transcription: 'Another test message.',
+      createdAt: new Date('2024-01-15T11:00:00Z').toISOString(),
+      listened: true
+    };
+
+    await mockRedis.zadd('voicemails:index', { score: Date.parse(voicemail1.createdAt), member: 'RE111' });
+    await mockRedis.zadd('voicemails:index', { score: Date.parse(voicemail2.createdAt), member: 'RE222' });
+    await mockRedis.set('voicemail:RE111', JSON.stringify(voicemail1));
+    await mockRedis.set('voicemail:RE222', JSON.stringify(voicemail2));
+
+    // Import handler after mocking
+    const listHandler = (await import('../../api/voicemail/list.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'authorization': 'Bearer test-secret-token-12345',
+        'accept': 'application/json'
+      }
+    });
+
+    await listHandler(req, res);
+
+    // Verify response
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = JSON.parse(res._getData());
+
+    expect(responseData.success).toBe(true);
+    expect(responseData.voicemails).toHaveLength(2);
+    expect(responseData.total).toBe(2);
+    expect(responseData.count).toBe(2);
+    expect(responseData.limit).toBe(50); // default limit
+    expect(responseData.offset).toBe(0);
+
+    // Verify voicemails are returned in reverse chronological order (newest first)
+    expect(responseData.voicemails[0].id).toBe('RE222');
+    expect(responseData.voicemails[1].id).toBe('RE111');
+  });
+
+  test('rejects request with invalid Bearer token', async () => {
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    const listHandler = (await import('../../api/voicemail/list.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'authorization': 'Bearer wrong-token',
+        'accept': 'application/json'
+      }
+    });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    const responseData = JSON.parse(res._getData());
+    expect(responseData.error).toBe('Unauthorized - Invalid credentials');
+  });
+
+  test('rejects request with missing Authorization header', async () => {
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    const listHandler = (await import('../../api/voicemail/list.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'accept': 'application/json'
+        // No authorization header
+      }
+    });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    const responseData = JSON.parse(res._getData());
+    expect(responseData.error).toBe('Unauthorized - Invalid credentials');
+  });
+
+  test('accepts token without Bearer prefix', async () => {
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    const listHandler = (await import('../../api/voicemail/list.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'authorization': 'test-secret-token-12345', // No "Bearer " prefix
+        'accept': 'application/json'
+      }
+    });
+
+    await listHandler(req, res);
+
+    // Should succeed
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  test('filters unlistened voicemails when unlistened_only=true', async () => {
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    // Add voicemails with different listened states
+    const unlistened = {
+      id: 'RE111',
+      recordingUrl: 'https://api.twilio.com/recordings/RE111',
+      duration: 45,
+      from: '+12345678901',
+      createdAt: new Date('2024-01-15T10:00:00Z').toISOString(),
+      listened: false
+    };
+
+    const listened = {
+      id: 'RE222',
+      recordingUrl: 'https://api.twilio.com/recordings/RE222',
+      duration: 30,
+      from: '+13334445555',
+      createdAt: new Date('2024-01-15T11:00:00Z').toISOString(),
+      listened: true
+    };
+
+    await mockRedis.zadd('voicemails:index', { score: Date.parse(unlistened.createdAt), member: 'RE111' });
+    await mockRedis.zadd('voicemails:index', { score: Date.parse(listened.createdAt), member: 'RE222' });
+    await mockRedis.set('voicemail:RE111', JSON.stringify(unlistened));
+    await mockRedis.set('voicemail:RE222', JSON.stringify(listened));
+
+    const listHandler = (await import('../../api/voicemail/list.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      query: {
+        unlistened_only: 'true'
+      },
+      headers: {
+        'authorization': 'Bearer test-secret-token-12345',
+        'accept': 'application/json'
+      }
+    });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = JSON.parse(res._getData());
+
+    // Should only return unlistened voicemail
+    expect(responseData.voicemails).toHaveLength(1);
+    expect(responseData.voicemails[0].id).toBe('RE111');
+    expect(responseData.voicemails[0].listened).toBe(false);
+  });
+
+  test('respects pagination with limit and offset', async () => {
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    // Add 5 voicemails
+    for (let i = 1; i <= 5; i++) {
+      const vm = {
+        id: `RE${i}${i}${i}`,
+        recordingUrl: `https://api.twilio.com/recordings/RE${i}${i}${i}`,
+        duration: 30 + i,
+        from: `+1234567890${i}`,
+        createdAt: new Date(`2024-01-15T1${i}:00:00Z`).toISOString(),
+        listened: false
+      };
+      await mockRedis.zadd('voicemails:index', { score: Date.parse(vm.createdAt), member: vm.id });
+      await mockRedis.set(`voicemail:${vm.id}`, JSON.stringify(vm));
+    }
+
+    const listHandler = (await import('../../api/voicemail/list.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      query: {
+        limit: '2',
+        offset: '1'
+      },
+      headers: {
+        'authorization': 'Bearer test-secret-token-12345',
+        'accept': 'application/json'
+      }
+    });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = JSON.parse(res._getData());
+
+    expect(responseData.voicemails).toHaveLength(2);
+    expect(responseData.limit).toBe(2);
+    expect(responseData.offset).toBe(1);
+    expect(responseData.total).toBe(5);
+
+    // Should get the 2nd and 3rd newest (skipping the first due to offset)
+    expect(responseData.voicemails[0].id).toBe('RE444');
+    expect(responseData.voicemails[1].id).toBe('RE333');
+  });
+
+  test('enforces maximum limit of 100', async () => {
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    const listHandler = (await import('../../api/voicemail/list.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      query: {
+        limit: '999' // Trying to request more than max
+      },
+      headers: {
+        'authorization': 'Bearer test-secret-token-12345',
+        'accept': 'application/json'
+      }
+    });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = JSON.parse(res._getData());
+
+    // Should be capped at 100
+    expect(responseData.limit).toBe(100);
+  });
+
+  test('enforces minimum limit of 1', async () => {
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    const listHandler = (await import('../../api/voicemail/list.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      query: {
+        limit: '-5' // Negative limit
+      },
+      headers: {
+        'authorization': 'Bearer test-secret-token-12345',
+        'accept': 'application/json'
+      }
+    });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = JSON.parse(res._getData());
+
+    // Should be set to minimum of 1
+    expect(responseData.limit).toBe(1);
+  });
+
+  test('returns HTML when Accept header includes text/html', async () => {
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    const voicemail = {
+      id: 'RE111',
+      recordingUrl: 'https://api.twilio.com/recordings/RE111',
+      duration: 45,
+      from: '+12345678901',
+      transcription: 'Test message',
+      createdAt: new Date().toISOString(),
+      listened: false
+    };
+
+    await mockRedis.zadd('voicemails:index', { score: Date.now(), member: 'RE111' });
+    await mockRedis.set('voicemail:RE111', JSON.stringify(voicemail));
+
+    const listHandler = (await import('../../api/voicemail/list.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'authorization': 'Bearer test-secret-token-12345',
+        'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+      }
+    });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getHeaders()['content-type']).toBe('text/html');
+
+    const html = res._getData();
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('O Cinema Voicemail Dashboard');
+    expect(html).toContain('+12345678901');
+    expect(html).toContain('Test message');
+  });
+
+  test('handles empty voicemail list gracefully', async () => {
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    // Don't add any voicemails - list is empty
+
+    const listHandler = (await import('../../api/voicemail/list.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'authorization': 'Bearer test-secret-token-12345',
+        'accept': 'application/json'
+      }
+    });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = JSON.parse(res._getData());
+
+    expect(responseData.success).toBe(true);
+    expect(responseData.voicemails).toEqual([]);
+    expect(responseData.total).toBe(0);
+    expect(responseData.count).toBe(0);
+  });
+
+  test('returns empty state HTML when no voicemails exist', async () => {
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    const listHandler = (await import('../../api/voicemail/list.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'authorization': 'Bearer test-secret-token-12345',
+        'accept': 'text/html'
+      }
+    });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const html = res._getData();
+
+    expect(html).toContain('No Voicemails Yet');
+    expect(html).toContain('When customers leave voicemails');
+  });
+
+  test('handles CORS preflight request', async () => {
+    const listHandler = (await import('../../api/voicemail/list.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'OPTIONS'
+    });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getHeaders()['access-control-allow-origin']).toBe('*');
+    expect(res._getHeaders()['access-control-allow-methods']).toBe('GET, OPTIONS');
+    expect(res._getHeaders()['access-control-allow-headers']).toBe('Content-Type, Authorization');
+  });
+
+  test('rejects non-GET requests (except OPTIONS)', async () => {
+    const listHandler = (await import('../../api/voicemail/list.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: {
+        'authorization': 'Bearer test-secret-token-12345'
+      }
+    });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    const responseData = JSON.parse(res._getData());
+    expect(responseData.error).toBe('Method not allowed');
+  });
+
+  test('returns 500 when STAFF_DASHBOARD_SECRET is not configured', async () => {
+    // Remove the secret
+    delete process.env.STAFF_DASHBOARD_SECRET;
+
+    const listHandler = (await import('../../api/voicemail/list.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'authorization': 'Bearer some-token'
+      }
+    });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    const responseData = JSON.parse(res._getData());
+    expect(responseData.error).toBe('Server configuration error');
+  });
+
+  test('uses timing-safe comparison for token validation', async () => {
+    // This test ensures that the timing attack vulnerability is prevented
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    const listHandler = (await import('../../api/voicemail/list.js?t=' + Date.now())).default;
+
+    // Try with a token that has same length but wrong content
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'authorization': 'Bearer test-secret-token-99999', // Same length, different content
+        'accept': 'application/json'
+      }
+    });
+
+    await listHandler(req, res);
+
+    // Should be rejected despite same length
+    expect(res._getStatusCode()).toBe(401);
+  });
+
+  test('handles malformed voicemail data in Redis gracefully', async () => {
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    // Add valid voicemail to index but corrupt data in storage
+    await mockRedis.zadd('voicemails:index', { score: Date.now(), member: 'RE111' });
+    await mockRedis.set('voicemail:RE111', 'invalid-json-{{{');
+
+    const listHandler = (await import('../../api/voicemail/list.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'authorization': 'Bearer test-secret-token-12345',
+        'accept': 'application/json'
+      }
+    });
+
+    await listHandler(req, res);
+
+    // Should still return 200, but skip the malformed record
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = JSON.parse(res._getData());
+
+    expect(responseData.success).toBe(true);
+    expect(responseData.voicemails).toEqual([]); // Empty because record was malformed
+    expect(responseData.total).toBe(1); // But total still shows 1 in index
+  });
+});

--- a/tests/integration/voicemail-transcription.test.js
+++ b/tests/integration/voicemail-transcription.test.js
@@ -1,0 +1,414 @@
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { createMocks } from 'node-mocks-http';
+import crypto from 'crypto';
+
+// Helper to generate Twilio signature
+function getExpectedTwilioSignature(authToken, url, params) {
+  const data = Object.keys(params)
+    .sort()
+    .reduce((acc, key) => acc + key + params[key], url);
+
+  return crypto
+    .createHmac('sha1', authToken)
+    .update(Buffer.from(data, 'utf-8'))
+    .digest('base64');
+}
+
+// Mock Redis client
+class MockRedis {
+  constructor() {
+    this.data = new Map();
+  }
+
+  async get(key) {
+    const value = this.data.get(key);
+    return value || null;
+  }
+
+  async set(key, value) {
+    this.data.set(key, value);
+    return 'OK';
+  }
+
+  clear() {
+    this.data.clear();
+  }
+}
+
+describe('Voicemail Transcription Callback (Integration Test)', () => {
+  let originalEnv;
+  let mockRedis;
+  let emailSendSpy;
+
+  beforeEach(() => {
+    // Save original environment
+    originalEnv = { ...process.env };
+
+    // Set test environment
+    process.env.BASE_URL = 'https://miami-theater-voice-agent.vercel.app';
+    process.env.TWILIO_AUTH_TOKEN = 'test-auth-token-12345';
+    process.env.TWILIO_ACCOUNT_SID = 'ACxxxxx';
+    process.env.RESEND_API_KEY = 'test-resend-key';
+    process.env.STAFF_EMAIL = 'staff@o-cinema.org';
+    process.env.FROM_EMAIL = 'noreply@o-cinema.org';
+    process.env.KV_REST_API_URL = 'https://test-redis.upstash.io';
+    process.env.KV_REST_API_TOKEN = 'test-token';
+
+    // Create mock Redis instance
+    mockRedis = new MockRedis();
+
+    // Mock the email sending function
+    emailSendSpy = jest.fn().mockResolvedValue({ id: 'email-456' });
+  });
+
+  afterEach(() => {
+    // Restore environment
+    process.env = originalEnv;
+    jest.resetModules();
+    jest.clearAllMocks();
+    if (mockRedis) {
+      mockRedis.clear();
+    }
+  });
+
+  test('updates voicemail with transcription when callback is received', async () => {
+    // Mock dependencies
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+    jest.unstable_mockModule('../../api/utils/voicemail-email.js', () => ({
+      sendVoicemailEmail: emailSendSpy
+    }));
+
+    // Pre-populate Redis with a voicemail record (as if callback already created it)
+    const recordingSid = 'RE1234567890abcdef1234567890abcdef';
+    const existingVoicemail = {
+      id: recordingSid,
+      recordingUrl: 'https://api.twilio.com/recordings/RE1234567890abcdef1234567890abcdef',
+      duration: 45,
+      callSid: 'CAxxxxx',
+      from: '+12345678901',
+      to: '+19876543210',
+      status: 'completed',
+      transcription: null,
+      createdAt: new Date('2024-01-15T10:30:00Z').toISOString(),
+      listened: false
+    };
+
+    await mockRedis.set(`voicemail:${recordingSid}`, JSON.stringify(existingVoicemail));
+
+    // Import handler after mocking
+    const transcriptionHandler = (await import('../../api/twilio/voicemail-transcription.js?t=' + Date.now())).default;
+
+    // Prepare transcription callback data (what Twilio sends)
+    const callbackUrl = 'https://miami-theater-voice-agent.vercel.app/api/twilio/voicemail-transcription';
+    const callbackParams = {
+      TranscriptionSid: 'TR9876543210fedcba9876543210fedcba',
+      TranscriptionText: 'Hello, I would like to know what movies are playing this weekend. Thank you.',
+      TranscriptionStatus: 'completed',
+      RecordingSid: recordingSid,
+      TranscriptionUrl: 'https://api.twilio.com/transcriptions/TR9876543210fedcba9876543210fedcba'
+    };
+
+    // Generate valid Twilio signature
+    const signature = getExpectedTwilioSignature(
+      process.env.TWILIO_AUTH_TOKEN,
+      callbackUrl,
+      callbackParams
+    );
+
+    // Create request
+    const { req, res } = createMocks({
+      method: 'POST',
+      url: '/api/twilio/voicemail-transcription',
+      headers: {
+        'x-twilio-signature': signature,
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app',
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: callbackParams
+    });
+
+    await transcriptionHandler(req, res);
+
+    // Verify response
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = JSON.parse(res._getData());
+    expect(responseData.success).toBe(true);
+
+    // Verify Redis was updated with transcription
+    const updatedVoicemail = await mockRedis.get(`voicemail:${recordingSid}`);
+    expect(updatedVoicemail).toBeTruthy();
+
+    const voicemailData = JSON.parse(updatedVoicemail);
+    expect(voicemailData.transcription).toBe(callbackParams.TranscriptionText);
+    expect(voicemailData.transcriptionSid).toBe(callbackParams.TranscriptionSid);
+    expect(voicemailData.transcriptionUrl).toBe(callbackParams.TranscriptionUrl);
+    expect(voicemailData.transcriptionUpdatedAt).toBeTruthy();
+
+    // Verify email notification was sent
+    expect(emailSendSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transcription: callbackParams.TranscriptionText,
+        transcriptionSid: callbackParams.TranscriptionSid
+      }),
+      'transcription'
+    );
+  });
+
+  test('rejects invalid Twilio signature', async () => {
+    // Mock dependencies
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+
+    const transcriptionHandler = (await import('../../api/twilio/voicemail-transcription.js?t=' + Date.now())).default;
+
+    const callbackParams = {
+      TranscriptionSid: 'TR9876543210fedcba9876543210fedcba',
+      TranscriptionText: 'This is a test transcription.',
+      TranscriptionStatus: 'completed',
+      RecordingSid: 'RE1234567890abcdef1234567890abcdef',
+      TranscriptionUrl: 'https://api.twilio.com/transcriptions/TR9876543210fedcba9876543210fedcba'
+    };
+
+    // Create request with INVALID signature
+    const { req, res } = createMocks({
+      method: 'POST',
+      url: '/api/twilio/voicemail-transcription',
+      headers: {
+        'x-twilio-signature': 'invalid-signature-xyz',
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app',
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: callbackParams
+    });
+
+    await transcriptionHandler(req, res);
+
+    // Should return 403 Forbidden
+    expect(res._getStatusCode()).toBe(403);
+    const responseData = JSON.parse(res._getData());
+    expect(responseData.error).toContain('Invalid signature');
+  });
+
+  test('handles missing voicemail record gracefully', async () => {
+    // Mock dependencies
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+    jest.unstable_mockModule('../../api/utils/voicemail-email.js', () => ({
+      sendVoicemailEmail: emailSendSpy
+    }));
+
+    // Note: We do NOT pre-populate Redis, so the voicemail doesn't exist
+
+    const transcriptionHandler = (await import('../../api/twilio/voicemail-transcription.js?t=' + Date.now())).default;
+
+    const callbackUrl = 'https://miami-theater-voice-agent.vercel.app/api/twilio/voicemail-transcription';
+    const callbackParams = {
+      TranscriptionSid: 'TR9876543210fedcba9876543210fedcba',
+      TranscriptionText: 'This transcription has no matching voicemail.',
+      TranscriptionStatus: 'completed',
+      RecordingSid: 'RE_DOES_NOT_EXIST',
+      TranscriptionUrl: 'https://api.twilio.com/transcriptions/TR9876543210fedcba9876543210fedcba'
+    };
+
+    const signature = getExpectedTwilioSignature(
+      process.env.TWILIO_AUTH_TOKEN,
+      callbackUrl,
+      callbackParams
+    );
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      url: '/api/twilio/voicemail-transcription',
+      headers: {
+        'x-twilio-signature': signature,
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app',
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: callbackParams
+    });
+
+    await transcriptionHandler(req, res);
+
+    // Should still return 200 (graceful handling)
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = JSON.parse(res._getData());
+    expect(responseData.success).toBe(true);
+
+    // Email should NOT have been sent (no voicemail to send about)
+    expect(emailSendSpy).not.toHaveBeenCalled();
+  });
+
+  test('skips transcription update when status is not completed', async () => {
+    // Mock dependencies
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+    jest.unstable_mockModule('../../api/utils/voicemail-email.js', () => ({
+      sendVoicemailEmail: emailSendSpy
+    }));
+
+    const recordingSid = 'RE1234567890abcdef1234567890abcdef';
+    const existingVoicemail = {
+      id: recordingSid,
+      recordingUrl: 'https://api.twilio.com/recordings/RE1234567890abcdef1234567890abcdef',
+      duration: 45,
+      from: '+12345678901',
+      transcription: null,
+      createdAt: new Date().toISOString(),
+      listened: false
+    };
+
+    await mockRedis.set(`voicemail:${recordingSid}`, JSON.stringify(existingVoicemail));
+
+    const transcriptionHandler = (await import('../../api/twilio/voicemail-transcription.js?t=' + Date.now())).default;
+
+    const callbackUrl = 'https://miami-theater-voice-agent.vercel.app/api/twilio/voicemail-transcription';
+    const callbackParams = {
+      TranscriptionSid: 'TR9876543210fedcba9876543210fedcba',
+      TranscriptionText: '',
+      TranscriptionStatus: 'failed', // NOT completed
+      RecordingSid: recordingSid,
+      TranscriptionUrl: 'https://api.twilio.com/transcriptions/TR9876543210fedcba9876543210fedcba'
+    };
+
+    const signature = getExpectedTwilioSignature(
+      process.env.TWILIO_AUTH_TOKEN,
+      callbackUrl,
+      callbackParams
+    );
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      url: '/api/twilio/voicemail-transcription',
+      headers: {
+        'x-twilio-signature': signature,
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app',
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: callbackParams
+    });
+
+    await transcriptionHandler(req, res);
+
+    // Should return 200
+    expect(res._getStatusCode()).toBe(200);
+
+    // Voicemail should NOT be updated (transcription still null)
+    const voicemailAfter = await mockRedis.get(`voicemail:${recordingSid}`);
+    const voicemailData = JSON.parse(voicemailAfter);
+    expect(voicemailData.transcription).toBeNull();
+    expect(voicemailData.transcriptionSid).toBeUndefined();
+
+    // No email sent
+    expect(emailSendSpy).not.toHaveBeenCalled();
+  });
+
+  test('handles empty transcription text gracefully', async () => {
+    // Mock dependencies
+    jest.unstable_mockModule('@upstash/redis', () => ({
+      Redis: jest.fn(() => mockRedis)
+    }));
+    jest.unstable_mockModule('../../api/utils/voicemail-email.js', () => ({
+      sendVoicemailEmail: emailSendSpy
+    }));
+
+    const recordingSid = 'RE1234567890abcdef1234567890abcdef';
+    const existingVoicemail = {
+      id: recordingSid,
+      recordingUrl: 'https://api.twilio.com/recordings/RE1234567890abcdef1234567890abcdef',
+      duration: 45,
+      from: '+12345678901',
+      transcription: null,
+      createdAt: new Date().toISOString(),
+      listened: false
+    };
+
+    await mockRedis.set(`voicemail:${recordingSid}`, JSON.stringify(existingVoicemail));
+
+    const transcriptionHandler = (await import('../../api/twilio/voicemail-transcription.js?t=' + Date.now())).default;
+
+    const callbackUrl = 'https://miami-theater-voice-agent.vercel.app/api/twilio/voicemail-transcription';
+    const callbackParams = {
+      TranscriptionSid: 'TR9876543210fedcba9876543210fedcba',
+      TranscriptionText: '', // Empty transcription
+      TranscriptionStatus: 'completed',
+      RecordingSid: recordingSid,
+      TranscriptionUrl: 'https://api.twilio.com/transcriptions/TR9876543210fedcba9876543210fedcba'
+    };
+
+    const signature = getExpectedTwilioSignature(
+      process.env.TWILIO_AUTH_TOKEN,
+      callbackUrl,
+      callbackParams
+    );
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      url: '/api/twilio/voicemail-transcription',
+      headers: {
+        'x-twilio-signature': signature,
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app',
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: callbackParams
+    });
+
+    await transcriptionHandler(req, res);
+
+    // Should return 200
+    expect(res._getStatusCode()).toBe(200);
+
+    // Voicemail should be updated with empty transcription
+    const voicemailAfter = await mockRedis.get(`voicemail:${recordingSid}`);
+    const voicemailData = JSON.parse(voicemailAfter);
+    expect(voicemailData.transcription).toBe('');
+    expect(voicemailData.transcriptionSid).toBe(callbackParams.TranscriptionSid);
+
+    // Email should NOT be sent (empty transcription text)
+    expect(emailSendSpy).not.toHaveBeenCalled();
+  });
+
+  test('rejects non-POST requests', async () => {
+    const transcriptionHandler = (await import('../../api/twilio/voicemail-transcription.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'GET'
+    });
+
+    await transcriptionHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    const responseData = JSON.parse(res._getData());
+    expect(responseData.error).toBe('Method not allowed');
+  });
+
+  test('returns 500 when TWILIO_AUTH_TOKEN is not configured', async () => {
+    // Remove auth token
+    delete process.env.TWILIO_AUTH_TOKEN;
+
+    const transcriptionHandler = (await import('../../api/twilio/voicemail-transcription.js?t=' + Date.now())).default;
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: {
+        'x-twilio-signature': 'some-signature'
+      },
+      body: {}
+    });
+
+    await transcriptionHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    const responseData = JSON.parse(res._getData());
+    expect(responseData.error).toBe('Server configuration error');
+  });
+});

--- a/tests/unit/showtimes-filters.test.js
+++ b/tests/unit/showtimes-filters.test.js
@@ -1,0 +1,219 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { formatDateYYYYMMDD, getEasternTimeDate, parseTime12Hour } from '../../api/utils/timezone.js';
+
+// Mock the filterPastShowtimes function since it's not exported
+// We'll test it indirectly through integration tests, but here we test the logic
+describe('Showtime Filtering Logic', () => {
+  describe('filterPastShowtimes - Logic Tests', () => {
+    // Helper function that mimics filterPastShowtimes logic
+    function shouldKeepShowtime(showtimeDate, showtimeTime, nowDate, nowHour, nowMinute) {
+      // If showtime is in the future (different day), keep it
+      if (showtimeDate > nowDate) return true;
+
+      // If showtime is in the past (different day), filter it out
+      if (showtimeDate < nowDate) return false;
+
+      // Same day - check the time
+      const parsed = parseTime12Hour(showtimeTime);
+      if (!parsed) return true;
+
+      const { hour, minute } = parsed;
+
+      // Compare times
+      if (hour > nowHour) return true;
+      if (hour < nowHour) return false;
+      return minute >= nowMinute;
+    }
+
+    describe('Date-based filtering', () => {
+      test('keeps showtimes from future dates', () => {
+        const result = shouldKeepShowtime('2025-10-15', '7:30 PM', '2025-10-14', 14, 30);
+        expect(result).toBe(true);
+      });
+
+      test('filters out showtimes from past dates', () => {
+        const result = shouldKeepShowtime('2025-10-13', '7:30 PM', '2025-10-14', 14, 30);
+        expect(result).toBe(false);
+      });
+
+      test('handles year boundary correctly', () => {
+        const result = shouldKeepShowtime('2026-01-01', '7:30 PM', '2025-12-31', 23, 30);
+        expect(result).toBe(true);
+      });
+
+      test('handles month boundary correctly', () => {
+        const result = shouldKeepShowtime('2025-11-01', '7:30 PM', '2025-10-31', 23, 30);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('Same-day time-based filtering', () => {
+      test('keeps showtime in the future (same day)', () => {
+        const result = shouldKeepShowtime('2025-10-14', '7:30 PM', '2025-10-14', 14, 30);
+        expect(result).toBe(true); // 7:30 PM (19:30) > 2:30 PM (14:30)
+      });
+
+      test('filters out showtime in the past (same day)', () => {
+        const result = shouldKeepShowtime('2025-10-14', '2:30 PM', '2025-10-14', 19, 30);
+        expect(result).toBe(false); // 2:30 PM (14:30) < 7:30 PM (19:30)
+      });
+
+      test('keeps showtime at exact current time', () => {
+        const result = shouldKeepShowtime('2025-10-14', '2:30 PM', '2025-10-14', 14, 30);
+        expect(result).toBe(true); // Equal times should be kept
+      });
+
+      test('filters out showtime 1 minute in the past', () => {
+        const result = shouldKeepShowtime('2025-10-14', '2:29 PM', '2025-10-14', 14, 30);
+        expect(result).toBe(false);
+      });
+
+      test('keeps showtime 1 minute in the future', () => {
+        const result = shouldKeepShowtime('2025-10-14', '2:31 PM', '2025-10-14', 14, 30);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('Boundary time cases', () => {
+      test('handles midnight correctly (12:00 AM)', () => {
+        const result = shouldKeepShowtime('2025-10-14', '12:00 AM', '2025-10-14', 0, 0);
+        expect(result).toBe(true); // Exact time
+      });
+
+      test('handles noon correctly (12:00 PM)', () => {
+        const result = shouldKeepShowtime('2025-10-14', '12:00 PM', '2025-10-14', 12, 0);
+        expect(result).toBe(true); // Exact time
+      });
+
+      test('handles 11:59 PM correctly', () => {
+        const result = shouldKeepShowtime('2025-10-14', '11:59 PM', '2025-10-14', 23, 59);
+        expect(result).toBe(true); // Exact time
+      });
+
+      test('filters out midnight when current time is 12:01 AM', () => {
+        const result = shouldKeepShowtime('2025-10-14', '12:00 AM', '2025-10-14', 0, 1);
+        expect(result).toBe(false);
+      });
+
+      test('keeps 12:01 AM when current time is midnight', () => {
+        const result = shouldKeepShowtime('2025-10-14', '12:01 AM', '2025-10-14', 0, 0);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('Edge cases with AM/PM transitions', () => {
+      test('handles transition from AM to PM', () => {
+        const morningShowtime = shouldKeepShowtime('2025-10-14', '11:59 AM', '2025-10-14', 12, 0);
+        expect(morningShowtime).toBe(false); // 11:59 AM is before 12:00 PM
+
+        const afternoonShowtime = shouldKeepShowtime('2025-10-14', '12:01 PM', '2025-10-14', 12, 0);
+        expect(afternoonShowtime).toBe(true); // 12:01 PM is after 12:00 PM
+      });
+
+      test('handles transition from PM to AM (end of day)', () => {
+        const lateShowtime = shouldKeepShowtime('2025-10-14', '11:59 PM', '2025-10-14', 23, 58);
+        expect(lateShowtime).toBe(true); // 11:59 PM is after 11:58 PM
+      });
+    });
+
+    describe('Invalid time handling', () => {
+      test('keeps showtimes with invalid time formats', () => {
+        const result = shouldKeepShowtime('2025-10-14', 'invalid-time', '2025-10-14', 14, 30);
+        expect(result).toBe(true); // Invalid formats should be kept (defensive)
+      });
+
+      test('keeps showtimes with missing time data', () => {
+        const result = shouldKeepShowtime('2025-10-14', '', '2025-10-14', 14, 30);
+        expect(result).toBe(true); // Missing data should be kept (defensive)
+      });
+    });
+
+    describe('Real-world scenarios', () => {
+      test('evening movie showings at 2:30 PM current time', () => {
+        const currentDate = '2025-10-14';
+        const currentHour = 14; // 2:30 PM
+        const currentMinute = 30;
+
+        // Morning show (past)
+        expect(shouldKeepShowtime(currentDate, '10:00 AM', currentDate, currentHour, currentMinute)).toBe(false);
+
+        // Afternoon show (past)
+        expect(shouldKeepShowtime(currentDate, '2:00 PM', currentDate, currentHour, currentMinute)).toBe(false);
+
+        // Current show (edge case - should keep)
+        expect(shouldKeepShowtime(currentDate, '2:30 PM', currentDate, currentHour, currentMinute)).toBe(true);
+
+        // Evening show (future)
+        expect(shouldKeepShowtime(currentDate, '7:30 PM', currentDate, currentHour, currentMinute)).toBe(true);
+
+        // Late show (future)
+        expect(shouldKeepShowtime(currentDate, '10:00 PM', currentDate, currentHour, currentMinute)).toBe(true);
+      });
+
+      test('late night viewing at 11:30 PM', () => {
+        const currentDate = '2025-10-14';
+        const currentHour = 23; // 11:30 PM
+        const currentMinute = 30;
+
+        // All earlier shows should be filtered
+        expect(shouldKeepShowtime(currentDate, '7:00 PM', currentDate, currentHour, currentMinute)).toBe(false);
+        expect(shouldKeepShowtime(currentDate, '10:00 PM', currentDate, currentHour, currentMinute)).toBe(false);
+
+        // Very late show should be kept
+        expect(shouldKeepShowtime(currentDate, '11:45 PM', currentDate, currentHour, currentMinute)).toBe(true);
+
+        // Tomorrow's midnight show
+        expect(shouldKeepShowtime(currentDate, '11:59 PM', currentDate, currentHour, currentMinute)).toBe(true);
+      });
+
+      test('morning viewing at 9:00 AM', () => {
+        const currentDate = '2025-10-14';
+        const currentHour = 9; // 9:00 AM
+        const currentMinute = 0;
+
+        // Early morning shows
+        expect(shouldKeepShowtime(currentDate, '10:00 AM', currentDate, currentHour, currentMinute)).toBe(true);
+        expect(shouldKeepShowtime(currentDate, '11:30 AM', currentDate, currentHour, currentMinute)).toBe(true);
+
+        // All afternoon/evening shows
+        expect(shouldKeepShowtime(currentDate, '2:30 PM', currentDate, currentHour, currentMinute)).toBe(true);
+        expect(shouldKeepShowtime(currentDate, '7:00 PM', currentDate, currentHour, currentMinute)).toBe(true);
+      });
+    });
+
+    describe('Integration with timezone utilities', () => {
+      test('works with real Eastern Time dates', () => {
+        const todayET = getEasternTimeDate();
+        const todayStr = formatDateYYYYMMDD(todayET);
+        const currentHour = todayET.getHours();
+        const currentMinute = todayET.getMinutes();
+
+        // Tomorrow's showtime should always be kept
+        const tomorrow = new Date(todayET);
+        tomorrow.setDate(tomorrow.getDate() + 1);
+        const tomorrowStr = formatDateYYYYMMDD(tomorrow);
+
+        const result = shouldKeepShowtime(tomorrowStr, '7:30 PM', todayStr, currentHour, currentMinute);
+        expect(result).toBe(true);
+      });
+
+      test('works with parseTime12Hour for various formats', () => {
+        const testTimes = [
+          '12:00 AM',
+          '6:30 AM',
+          '12:00 PM',
+          '3:45 PM',
+          '7:30 PM',
+          '11:59 PM'
+        ];
+
+        testTimes.forEach(time => {
+          const parsed = parseTime12Hour(time);
+          expect(parsed).not.toBe(null);
+          expect(parsed).toHaveProperty('hour');
+          expect(parsed).toHaveProperty('minute');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This commit introduces a series of unit and integration tests focused on the showtime filtering logic and timezone utility functions. The tests cover various scenarios, including date-based filtering, same-day time-based filtering, handling of AM/PM transitions, and date and time formatting in Eastern Time. Additionally, the tests ensure that invalid inputs are handled gracefully and that the logic correctly interprets different time formats.