### PR TITLE
fix(security): add Twilio signature validation to voicemail.js + regression tests

### DIFF
--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -1,0 +1,119 @@
+name: Security Review – Twilio Code
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'api/twilio/**'
+      - 'api/utils/validate-twilio.js'
+
+jobs:
+  security-review:
+    name: Security Sentinel
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Collect changed Twilio files and diff
+        id: diff
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" -- \
+            'api/twilio/' \
+            'api/utils/validate-twilio.js')
+          echo "changed_files<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$CHANGED" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          git diff "$BASE" "$HEAD" -- \
+            api/twilio/ \
+            api/utils/validate-twilio.js \
+            > /tmp/twilio.diff
+
+      - name: Run security review
+        id: review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          DIFF=$(cat /tmp/twilio.diff)
+
+          REVIEW=$(claude -p "$(cat <<'PROMPT'
+You are a security expert specializing in Twilio webhook integrations.
+
+Review the following git diff for security vulnerabilities. Focus on:
+1. Twilio webhook signature validation — applied on every endpoint before any logic?
+2. Input validation and sanitization of Twilio POST body fields (RecordingSid, RecordingUrl, From, TranscriptionText, etc.)
+3. PII exposure — phone numbers or transcriptions logged to console?
+4. Authentication / authorization correctness
+5. SSRF or injection risks (e.g., unvalidated URLs stored or rendered as links)
+6. Host header injection in URL construction used for HMAC verification
+7. CORS headers on server-to-server webhook endpoints (should not be present)
+8. Any other OWASP Top-10 concerns
+
+Output format:
+- Start with a one-paragraph summary of the change and its overall risk level.
+- List findings as: **[SEVERITY] Title** — description and line reference.
+- If no issues are found, say so explicitly.
+- End with a "Positive findings" section noting any security practices done correctly.
+
+Keep the review concise and actionable. Severities: Critical / High / Medium / Low / Info.
+
+--- DIFF ---
+$DIFF
+PROMPT
+          )" --max-turns 1 2>&1)
+
+          echo "review<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$REVIEW" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Post review as PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const changedFiles = `${{ steps.diff.outputs.changed_files }}`.trim();
+            const review = `${{ steps.review.outputs.review }}`;
+
+            const fileList = changedFiles
+              .split('\n')
+              .filter(Boolean)
+              .map(f => `- \`${f}\``)
+              .join('\n');
+
+            const body = [
+              '## 🔒 Security Review – Twilio Code',
+              '',
+              '**Files reviewed:**',
+              fileList,
+              '',
+              '---',
+              '',
+              review,
+              '',
+              '---',
+              '*Automated review by [Claude Code](https://claude.ai/code) security-sentinel · [workflow](.github/workflows/security-review.yml)*'
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });

--- a/api/twilio/voicemail.js
+++ b/api/twilio/voicemail.js
@@ -1,6 +1,7 @@
 // api/twilio/voicemail.js
 // Twilio voicemail TwiML endpoint
 import twilio from 'twilio';
+import { validateTwilioRequest } from '../utils/validate-twilio.js';
 
 const { twiml } = twilio;
 
@@ -56,6 +57,12 @@ export default async function handler(req, res) {
 
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  // Validate Twilio webhook signature
+  const validation = validateTwilioRequest(req);
+  if (!validation.isValid) {
+    return res.status(validation.statusCode).json({ error: validation.error });
   }
 
   try {

--- a/tests/integration/voicemail-callback.test.js
+++ b/tests/integration/voicemail-callback.test.js
@@ -112,16 +112,22 @@ describe('Voicemail Callback Flow (E2E Integration Test)', () => {
     // Import handler after setting up environment
     const handler = (await import('../../api/twilio/voicemail.js')).default;
 
+    const voicemailBody = { From: '+12345678901', To: '+19876543210', CallSid: 'CAxxxxx' };
+    const voicemailUrl = 'https://miami-theater-voice-agent.vercel.app/api/twilio/voicemail';
+    const voicemailSig = getExpectedTwilioSignature(
+      process.env.TWILIO_AUTH_TOKEN, voicemailUrl, voicemailBody
+    );
+
     const { req, res } = createMocks({
       method: 'POST',
+      url: '/api/twilio/voicemail',
       headers: {
-        'content-type': 'application/x-www-form-urlencoded'
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-twilio-signature': voicemailSig,
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app'
       },
-      body: {
-        From: '+12345678901',
-        To: '+19876543210',
-        CallSid: 'CAxxxxx'
-      }
+      body: voicemailBody
     });
 
     await handler(req, res);
@@ -281,16 +287,22 @@ describe('Voicemail Callback Flow (E2E Integration Test)', () => {
     // Step 1: Get TwiML from voicemail endpoint
     const voicemailHandler = (await import('../../api/twilio/voicemail.js?t=' + Date.now())).default;
 
+    const e2eVoicemailBody = { From: '+12345678901', To: '+19876543210', CallSid: 'CAxxxxx' };
+    const e2eVoicemailUrl = 'https://miami-theater-voice-agent.vercel.app/api/twilio/voicemail';
+    const e2eVoicemailSig = getExpectedTwilioSignature(
+      process.env.TWILIO_AUTH_TOKEN, e2eVoicemailUrl, e2eVoicemailBody
+    );
+
     const { req: voicemailReq, res: voicemailRes } = createMocks({
       method: 'POST',
+      url: '/api/twilio/voicemail',
       headers: {
-        'content-type': 'application/x-www-form-urlencoded'
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-twilio-signature': e2eVoicemailSig,
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'miami-theater-voice-agent.vercel.app'
       },
-      body: {
-        From: '+12345678901',
-        To: '+19876543210',
-        CallSid: 'CAxxxxx'
-      }
+      body: e2eVoicemailBody
     });
 
     await voicemailHandler(voicemailReq, voicemailRes);

--- a/tests/unit/voicemail-caller-resolution.test.js
+++ b/tests/unit/voicemail-caller-resolution.test.js
@@ -1,5 +1,15 @@
 import { describe, test, expect, jest, beforeAll, beforeEach } from '@jest/globals';
 import { createMocks } from 'node-mocks-http';
+import crypto from 'crypto';
+
+const HOST = 'miami-theater-voice-agent.vercel.app';
+const AUTH_TOKEN = 'test-auth-token';
+
+/** Reproduce Twilio's HMAC-SHA1 signing algorithm */
+function twilioSignature(url, params) {
+  const data = Object.keys(params).sort().reduce((acc, k) => acc + k + params[k], url);
+  return crypto.createHmac('sha1', AUTH_TOKEN).update(Buffer.from(data, 'utf-8')).digest('base64');
+}
 
 // Stable mock reference - shared between the factory closure and individual tests
 // so each test can control what conferences.list() returns via mockResolvedValue / mockRejectedValue
@@ -27,6 +37,12 @@ jest.unstable_mockModule('twilio', () => {
     conferences: { list: mockConferencesList }
   }));
   MockTwilio.twiml = { VoiceResponse: MockVoiceResponse };
+  // validate-twilio.js calls twilio.validateRequest — provide the real algorithm
+  MockTwilio.validateRequest = (authToken, signature, url, params) => {
+    const data = Object.keys(params).sort().reduce((acc, k) => acc + k + params[k], url);
+    const expected = crypto.createHmac('sha1', authToken).update(Buffer.from(data, 'utf-8')).digest('base64');
+    return expected === signature;
+  };
 
   return { default: MockTwilio };
 });
@@ -48,12 +64,22 @@ describe('resolveOriginalCaller (via voicemail handler)', () => {
     process.env.BASE_URL = 'https://miami-theater-voice-agent.vercel.app';
   });
 
-  /** POST request that Twilio would send when a call arrives */
+  /** POST request that Twilio would send when a call arrives, with a valid signature */
   function makeRequest(from = '+12345678901') {
+    const body = { From: from, To: '+19876543210', CallSid: 'CAxxxxx' };
+    const url = '/api/twilio/voicemail';
+    const sig = twilioSignature(`https://${HOST}${url}`, body);
+
     return createMocks({
       method: 'POST',
-      headers: { 'content-type': 'application/x-www-form-urlencoded' },
-      body: { From: from, To: '+19876543210', CallSid: 'CAxxxxx' }
+      url,
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-twilio-signature': sig,
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': HOST,
+      },
+      body
     });
   }
 


### PR DESCRIPTION
## Summary

- **CRITICAL-1 fix**: `api/twilio/voicemail.js` was the only Twilio webhook endpoint missing `validateTwilioRequest`. Unauthenticated requests could receive TwiML and supply arbitrary `From` values. Added the same guard used by all three callback handlers.
- Add regression tests for the two bugs fixed in PR #25 (conference-based caller resolution and Twilio signature validation with query params)
- Add GitHub Actions workflow to automatically run a security review on any PR touching `api/twilio/` or `api/utils/validate-twilio.js`

## Changes

| File | Change |
|---|---|
| `api/twilio/voicemail.js` | Add `validateTwilioRequest` — rejects unsigned requests with 403 |
| `tests/unit/voicemail-caller-resolution.test.js` | 7 unit tests for `resolveOriginalCaller`; updated to send signed requests |
| `tests/unit/validate-twilio.test.js` | Negative regression test: stripped-URL signature is rejected when URL has query params |
| `tests/integration/voicemail-callback.test.js` | Updated 2 tests to sign voicemail endpoint requests |
| `.github/workflows/security-review.yml` | Auto-runs Claude Code security sentinel on Twilio PRs |

## Test plan

- [x] All 347 unit + integration tests pass
- [x] `voicemail-caller-resolution` tests verify conference regex, fallback, API error, and malformed name cases
- [x] Negative regression test confirms old stripped-URL signature behavior is permanently rejected
- [x] Security review workflow triggers on `api/twilio/**` and `api/utils/validate-twilio.js` path changes

> **Note:** Requires `ANTHROPIC_API_KEY` secret in repo settings for the security review workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)